### PR TITLE
[lib/Text/Markdown.pm, t/text.t] Newlines at EOF

### DIFF
--- a/lib/Text/Markdown.pm
+++ b/lib/Text/Markdown.pm
@@ -144,7 +144,7 @@ sub extract_tspans($text) {
 
 grammar Markdown {
     token TOP {
-        ^ <paragraph>* % [\n\n+] $
+        ^ <paragraph>* % [\n\n+] \n* $
         { make Document.new(:children($<paragraph>».ast)) }
     }
 

--- a/t/text.t
+++ b/t/text.t
@@ -15,6 +15,13 @@ use Text::Markdown;
 }
 
 {
+    my $doc = parse-markdown "One slide.\n\n\nTwo paragraphs and some blanks.\n\n\n\n";
+
+    is +$doc.children, 2, "input ending with newline chars";
+    is $doc.children[1].text, "Two paragraphs and some blanks.", "any number of blank lines between paragraphs";
+}
+
+{
     my $doc = parse-markdown "One slide with *italics* in it.";
     my $para = $doc.children[0];
 


### PR DESCRIPTION
Hi masak,
corrected and cleaned up this PR.
The second test in text.t breaks when [\n\n+] is replaced by [\n\n] - needs to be foolproof for people like me ;-)
Thanks for your help !
Ennio
